### PR TITLE
Intelligently check for salt collision

### DIFF
--- a/script/Anvil.s.sol
+++ b/script/Anvil.s.sol
@@ -30,7 +30,7 @@ contract CounterScript is Script {
 
         // Mine a salt that will produce a hook address with the correct flags
         (address hookAddress, bytes32 salt) =
-            HookMiner.find(CREATE2_DEPLOYER, flags, 1000, type(Counter).creationCode, abi.encode(address(manager)));
+            HookMiner.find(CREATE2_DEPLOYER, flags, type(Counter).creationCode, abi.encode(address(manager)));
 
         // Deploy the hook using CREATE2
         vm.broadcast();

--- a/script/CounterDeploy.s.sol
+++ b/script/CounterDeploy.s.sol
@@ -25,9 +25,8 @@ contract CounterScript is Script {
         );
 
         // Mine a salt that will produce a hook address with the correct flags
-        (address hookAddress, bytes32 salt) = HookMiner.find(
-            CREATE2_DEPLOYER, flags, 1000, type(Counter).creationCode, abi.encode(address(GOERLI_POOLMANAGER))
-        );
+        (address hookAddress, bytes32 salt) =
+            HookMiner.find(CREATE2_DEPLOYER, flags, type(Counter).creationCode, abi.encode(address(GOERLI_POOLMANAGER)));
 
         // Deploy the hook using CREATE2
         vm.broadcast();

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -33,7 +33,7 @@ contract CounterTest is HookTest, Deployers, GasSnapshot {
                 | Hooks.AFTER_MODIFY_POSITION_FLAG
         );
         (address hookAddress, bytes32 salt) =
-            HookMiner.find(address(this), flags, 0, type(Counter).creationCode, abi.encode(address(manager)));
+            HookMiner.find(address(this), flags, type(Counter).creationCode, abi.encode(address(manager)));
         counter = new Counter{salt: salt}(IPoolManager(address(manager)));
         require(address(counter) == hookAddress, "CounterTest: hook address mismatch");
 


### PR DESCRIPTION
Instead of requiring a `seed` (salt offset), intelligently check if a minted salt has a deployment already