### PR TITLE
chore: update v4-core:latest

### DIFF
--- a/01a_CreatePool.s.sol
+++ b/01a_CreatePool.s.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "forge-std/Script.sol";
+import "forge-std/console.sol";
+import {PoolInitializeTest} from "@uniswap/v4-core/contracts/test/PoolInitializeTest.sol";
+import {IHooks} from "@uniswap/v4-core/contracts/interfaces/IHooks.sol";
+import {PoolKey} from "@uniswap/v4-core/contracts/types/PoolKey.sol";
+import {CurrencyLibrary, Currency} from "@uniswap/v4-core/contracts/types/Currency.sol";
+import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/contracts/types/PoolId.sol";
+
+contract CreatePoolScript is Script {
+    using CurrencyLibrary for Currency;
+
+    //addresses with contracts deployed
+    address constant POOL_INITIALIZE_ROUTER = address(0x0); // TODO: Update once deployed
+    address constant MUNI_ADDRESS = address(0xbD97BF168FA913607b996fab823F88610DCF7737); //mUNI deployed to GOERLI -- insert your own contract address here
+    address constant MUSDC_ADDRESS = address(0xa468864e673a807572598AB6208E49323484c6bF); //mUSDC deployed to GOERLI -- insert your own contract address here
+    address constant HOOK_ADDRESS = address(0x3CA2cD9f71104a6e1b67822454c725FcaeE35fF6); //address of the hook contract deployed to goerli -- you can use this hook address or deploy your own!
+
+    PoolInitializeTest initializeRouter = PoolInitializeTest(POOL_INITIALIZE_ROUTER);
+
+    function run() external {
+        // sort the tokens!
+        address token0 = uint160(MUSDC_ADDRESS) < uint160(MUNI_ADDRESS) ? MUSDC_ADDRESS : MUNI_ADDRESS;
+        address token1 = uint160(MUSDC_ADDRESS) < uint160(MUNI_ADDRESS) ? MUNI_ADDRESS : MUSDC_ADDRESS;
+        uint24 swapFee = 4000;
+        int24 tickSpacing = 10;
+
+        // floor(sqrt(1) * 2^96)
+        uint160 startingPrice = 79228162514264337593543950336;
+
+        bytes memory hookData = abi.encode(block.timestamp);
+
+        PoolKey memory pool = PoolKey({
+            currency0: Currency.wrap(token0),
+            currency1: Currency.wrap(token1),
+            fee: swapFee,
+            tickSpacing: tickSpacing,
+            hooks: IHooks(HOOK_ADDRESS)
+        });
+
+        // Turn the Pool into an ID so you can use it for modifying positions, swapping, etc.
+        PoolId id = PoolIdLibrary.toId(pool);
+        bytes32 idBytes = PoolId.unwrap(id);
+
+        console.log("Pool ID Below");
+        console.logBytes32(bytes32(idBytes));
+
+        vm.broadcast();
+        initializeRouter.initialize(pool, startingPrice, hookData);
+    }
+}

--- a/README.md
+++ b/README.md
@@ -14,19 +14,26 @@
 6. This template is built using Foundry
 
 <details>
-<summary><b>NOTE: v4-core versioning</b></summary>
+<summary>Updating to v4-template:latest</summary>
 
-Previous versions of `v4-template` accessed `v4-core` as the nested dependency of `v4-periphery`. With recent core activity, `v4-periphery` is slightly out of sync.
-
-As of 11/16/2023, `v4-template` has pinned a version of `v4-core` that is most similar to the testnet deployments.
-
-If there are issues, please do not hesistate on reaching out to [saucepoint](https://t.me/saucepoint)
+This template is actively maintained -- you can update the v4 dependencies, scripts, and helpers: 
+```bash
+git remote add template https://github.com/uniswapfoundation/v4-template
+git fetch template
+git merge template/main <BRANCH> --allow-unrelated-histories
+```
 
 </details>
 
 ---
 
-### Local Development (Anvil)
+# Linux / WSL2 (TSTORE/TLOAD)
+
+Please update [foundry.toml](foundry.toml#L9) to use the linux `solc`
+
+Mac users do not need to change anything by default
+
+## Set up
 
 *requires [foundry](https://book.getfoundry.sh)*
 
@@ -35,22 +42,25 @@ forge install
 forge test
 ```
 
+### Local Development (Anvil)
+
 Because v4 exceeds the bytecode limit of Ethereum and it's *business licensed*, we can only deploy & test hooks on [anvil](https://book.getfoundry.sh/anvil/).
 
 ```bash
-# start anvil, with a larger code limit
-anvil --code-size-limit 30000
+# start anvil
+anvil
 
 # in a new terminal
 forge script script/Anvil.s.sol \
     --rpc-url http://localhost:8545 \
     --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
-    --code-size-limit 30000 \
     --broadcast
 ```
 
 <details>
 <summary><h3>Goerli Testnet</h3></summary>
+
+NOTE: 11/21/2023, the Goerli deployment is out of sync with the latest v4. It is recommend to use local testing instead
 
 For testing on Goerli Testnet the Uniswap Foundation team has deployed a slimmed down version of the V4 contract (due to current contract size limits) on the network.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ forge test
 
 ### Local Development (Anvil)
 
-Because v4 exceeds the bytecode limit of Ethereum and it's *business licensed*, we can only deploy & test hooks on [anvil](https://book.getfoundry.sh/anvil/).
+Because v4 depends on TSTORE and its *business licensed*, you can only deploy & test hooks on [anvil](https://book.getfoundry.sh/anvil/)
 
 ```bash
 # start anvil

--- a/README.md
+++ b/README.md
@@ -47,8 +47,9 @@ forge test
 Because v4 depends on TSTORE and its *business licensed*, you can only deploy & test hooks on [anvil](https://book.getfoundry.sh/anvil/)
 
 ```bash
-# start anvil
-anvil
+# start anvil with TSTORE support
+# (`foundryup`` to update if cancun is not an option)
+anvil --hardfork cancun
 
 # in a new terminal
 forge script script/Anvil.s.sol \

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,5 +4,9 @@ out = "out"
 libs = ["lib"]
 ffi = true
 fs_permissions = [{ access = "read-write", path = ".forge-snapshots/"}]
+cancun = true
+
+# For Linux/WSL2 systems, please change to `lib/v4-core/bin/solc-static-linux`
+solc = "lib/v4-core/bin/solc-mac"
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/script/Anvil.s.sol
+++ b/script/Anvil.s.sol
@@ -2,12 +2,18 @@
 pragma solidity ^0.8.19;
 
 import "forge-std/Script.sol";
+import {IHooks} from "@uniswap/v4-core/contracts/interfaces/IHooks.sol";
 import {Hooks} from "@uniswap/v4-core/contracts/libraries/Hooks.sol";
 import {PoolManager} from "@uniswap/v4-core/contracts/PoolManager.sol";
 import {IPoolManager} from "@uniswap/v4-core/contracts/interfaces/IPoolManager.sol";
 import {PoolModifyPositionTest} from "@uniswap/v4-core/contracts/test/PoolModifyPositionTest.sol";
 import {PoolSwapTest} from "@uniswap/v4-core/contracts/test/PoolSwapTest.sol";
 import {PoolDonateTest} from "@uniswap/v4-core/contracts/test/PoolDonateTest.sol";
+import {PoolKey} from "@uniswap/v4-core/contracts/types/PoolKey.sol";
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {Constants} from "@uniswap/v4-core/contracts/../test/utils/Constants.sol";
+import {TickMath} from "@uniswap/v4-core/contracts/libraries/TickMath.sol";
+import {CurrencyLibrary, Currency} from "@uniswap/v4-core/contracts/types/Currency.sol";
 import {Counter} from "../src/Counter.sol";
 import {HookMiner} from "../test/utils/HookMiner.sol";
 
@@ -20,28 +26,104 @@ contract CounterScript is Script {
 
     function run() public {
         vm.broadcast();
-        PoolManager manager = new PoolManager(500000);
+        IPoolManager manager = deployPoolManager();
 
         // hook contracts must have specific flags encoded in the address
-        uint160 flags = uint160(
+        uint160 permissions = uint160(
             Hooks.BEFORE_SWAP_FLAG | Hooks.AFTER_SWAP_FLAG | Hooks.BEFORE_MODIFY_POSITION_FLAG
                 | Hooks.AFTER_MODIFY_POSITION_FLAG
         );
 
-        // Mine a salt that will produce a hook address with the correct flags
+        // Mine a salt that will produce a hook address with the correct permissions
         (address hookAddress, bytes32 salt) =
-            HookMiner.find(CREATE2_DEPLOYER, flags, type(Counter).creationCode, abi.encode(address(manager)));
+            HookMiner.find(CREATE2_DEPLOYER, permissions, type(Counter).creationCode, abi.encode(address(manager)));
 
-        // Deploy the hook using CREATE2
+        // ----------------------------- //
+        // Deploy the hook using CREATE2 //
+        // ----------------------------- //
         vm.broadcast();
-        Counter counter = new Counter{salt: salt}(IPoolManager(address(manager)));
+        Counter counter = new Counter{salt: salt}(manager);
         require(address(counter) == hookAddress, "CounterScript: hook address mismatch");
 
         // Additional helpers for interacting with the pool
         vm.startBroadcast();
-        new PoolModifyPositionTest(IPoolManager(address(manager)));
-        new PoolSwapTest(IPoolManager(address(manager)));
-        new PoolDonateTest(IPoolManager(address(manager)));
+        (PoolModifyPositionTest lpRouter, PoolSwapTest swapRouter,) = deployRouters(manager);
         vm.stopBroadcast();
+
+        // test the lifecycle (create pool, add liquidity, swap)
+        vm.startBroadcast();
+        testLifecycle(address(counter), manager, lpRouter, swapRouter);
+        vm.stopBroadcast();
+    }
+
+    // -----------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------
+    function deployPoolManager() internal returns (IPoolManager) {
+        return IPoolManager(address(new PoolManager(500000)));
+    }
+
+    function deployRouters(IPoolManager manager)
+        internal
+        returns (PoolModifyPositionTest lpRouter, PoolSwapTest swapRouter, PoolDonateTest donateRouter)
+    {
+        lpRouter = new PoolModifyPositionTest(manager);
+        swapRouter = new PoolSwapTest(manager);
+        donateRouter = new PoolDonateTest(manager);
+    }
+
+    function deployTokens() internal returns (MockERC20 token0, MockERC20 token1) {
+        MockERC20 tokenA = new MockERC20("MockA", "A", 18);
+        MockERC20 tokenB = new MockERC20("MockB", "B", 18);
+        if (uint160(address(tokenA)) < uint160(address(tokenB))) {
+            token0 = tokenA;
+            token1 = tokenB;
+        } else {
+            token0 = tokenB;
+            token1 = tokenA;
+        }
+    }
+
+    function testLifecycle(address hook, IPoolManager manager, PoolModifyPositionTest lpRouter, PoolSwapTest swapRouter)
+        internal
+    {
+        (MockERC20 token0, MockERC20 token1) = deployTokens();
+        token0.mint(msg.sender, 100_000 ether);
+        token1.mint(msg.sender, 100_000 ether);
+
+        bytes memory ZERO_BYTES = new bytes(0);
+
+        // initialize the pool
+        int24 tickSpacing = 60;
+        PoolKey memory poolKey =
+            PoolKey(Currency.wrap(address(token0)), Currency.wrap(address(token1)), 3000, tickSpacing, IHooks(hook));
+        manager.initialize(poolKey, Constants.SQRT_RATIO_1_1, ZERO_BYTES);
+
+        // approve the tokens to the routers
+        token0.approve(address(lpRouter), type(uint256).max);
+        token1.approve(address(lpRouter), type(uint256).max);
+        token0.approve(address(swapRouter), type(uint256).max);
+        token1.approve(address(swapRouter), type(uint256).max);
+
+        // add full range liquidity to the pool
+        lpRouter.modifyPosition(
+            poolKey,
+            IPoolManager.ModifyPositionParams(
+                TickMath.minUsableTick(tickSpacing), TickMath.maxUsableTick(tickSpacing), 100 ether
+            ),
+            ZERO_BYTES
+        );
+
+        // swap some tokens
+        bool zeroForOne = true;
+        int256 amountSpecified = 1 ether;
+        IPoolManager.SwapParams memory params = IPoolManager.SwapParams({
+            zeroForOne: zeroForOne,
+            amountSpecified: amountSpecified,
+            sqrtPriceLimitX96: zeroForOne ? TickMath.MIN_SQRT_RATIO + 1 : TickMath.MAX_SQRT_RATIO - 1 // unlimited impact
+        });
+        PoolSwapTest.TestSettings memory testSettings =
+            PoolSwapTest.TestSettings({withdrawTokens: true, settleUsingTransfer: true});
+        swapRouter.swap(poolKey, params, testSettings, ZERO_BYTES);
     }
 }

--- a/src/Counter.sol
+++ b/src/Counter.sol
@@ -34,7 +34,8 @@ contract Counter is BaseHook {
             beforeSwap: true,
             afterSwap: true,
             beforeDonate: false,
-            afterDonate: false
+            afterDonate: false,
+            noOp: false
         });
     }
 

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -40,7 +40,7 @@ contract CounterTest is HookTest {
         // Create the pool
         poolKey = PoolKey(Currency.wrap(address(token0)), Currency.wrap(address(token1)), 3000, 60, IHooks(counter));
         poolId = poolKey.toId();
-        manager.initialize(poolKey, Constants.SQRT_RATIO_1_1, ZERO_BYTES);
+        initializeRouter.initialize(poolKey, Constants.SQRT_RATIO_1_1, ZERO_BYTES);
 
         // Provide liquidity to the pool
         modifyPositionRouter.modifyPosition(poolKey, IPoolManager.ModifyPositionParams(-60, 60, 10 ether), ZERO_BYTES);

--- a/test/Counter.t.sol
+++ b/test/Counter.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.19;
 
 import "forge-std/Test.sol";
-import {GasSnapshot} from "forge-gas-snapshot/GasSnapshot.sol";
 import {IHooks} from "@uniswap/v4-core/contracts/interfaces/IHooks.sol";
 import {Hooks} from "@uniswap/v4-core/contracts/libraries/Hooks.sol";
 import {TickMath} from "@uniswap/v4-core/contracts/libraries/TickMath.sol";
@@ -10,13 +9,13 @@ import {IPoolManager} from "@uniswap/v4-core/contracts/interfaces/IPoolManager.s
 import {PoolKey} from "@uniswap/v4-core/contracts/types/PoolKey.sol";
 import {BalanceDelta} from "@uniswap/v4-core/contracts/types/BalanceDelta.sol";
 import {PoolId, PoolIdLibrary} from "@uniswap/v4-core/contracts/types/PoolId.sol";
-import {Deployers} from "@uniswap/v4-core/contracts/../test/utils/Deployers.sol";
+import {Constants} from "@uniswap/v4-core/contracts/../test/utils/Constants.sol";
 import {CurrencyLibrary, Currency} from "@uniswap/v4-core/contracts/types/Currency.sol";
 import {HookTest} from "./utils/HookTest.sol";
 import {Counter} from "../src/Counter.sol";
 import {HookMiner} from "./utils/HookMiner.sol";
 
-contract CounterTest is HookTest, Deployers, GasSnapshot {
+contract CounterTest is HookTest {
     using PoolIdLibrary for PoolKey;
     using CurrencyLibrary for Currency;
 
@@ -41,7 +40,7 @@ contract CounterTest is HookTest, Deployers, GasSnapshot {
         // Create the pool
         poolKey = PoolKey(Currency.wrap(address(token0)), Currency.wrap(address(token1)), 3000, 60, IHooks(counter));
         poolId = poolKey.toId();
-        manager.initialize(poolKey, SQRT_RATIO_1_1, ZERO_BYTES);
+        manager.initialize(poolKey, Constants.SQRT_RATIO_1_1, ZERO_BYTES);
 
         // Provide liquidity to the pool
         modifyPositionRouter.modifyPosition(poolKey, IPoolManager.ModifyPositionParams(-60, 60, 10 ether), ZERO_BYTES);

--- a/test/utils/HookMiner.sol
+++ b/test/utils/HookMiner.sol
@@ -4,8 +4,8 @@ pragma solidity ^0.8.20;
 /// @title HookMiner - a library for mining hook addresses
 /// @dev This library is intended for `forge test` environments. There may be gotchas when using salts in `forge script` or `forge create`
 library HookMiner {
-    // mask to slice out the top 8 bit of the address
-    uint160 constant FLAG_MASK = 0xFF << 152;
+    // mask to slice out the top 12 bit of the address
+    uint160 constant FLAG_MASK = 0xFFF << 148;
 
     // Maximum number of iterations to find a salt, avoid infinite loops
     uint256 constant MAX_LOOP = 10_000;

--- a/test/utils/HookMiner.sol
+++ b/test/utils/HookMiner.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity ^0.8.22;
+pragma solidity ^0.8.20;
 
 /// @title HookMiner - a library for mining hook addresses
 /// @dev This library is intended for `forge test` environments. There may be gotchas when using salts in `forge script` or `forge create`

--- a/test/utils/HookTest.sol
+++ b/test/utils/HookTest.sol
@@ -7,6 +7,7 @@ import {PoolManager} from "@uniswap/v4-core/contracts/PoolManager.sol";
 import {IPoolManager} from "@uniswap/v4-core/contracts/interfaces/IPoolManager.sol";
 import {PoolKey} from "@uniswap/v4-core/contracts/types/PoolKey.sol";
 import {BalanceDelta} from "@uniswap/v4-core/contracts/types/BalanceDelta.sol";
+import {PoolInitializeTest} from "@uniswap/v4-core/contracts/test/PoolInitializeTest.sol";
 import {PoolModifyPositionTest} from "@uniswap/v4-core/contracts/test/PoolModifyPositionTest.sol";
 import {PoolSwapTest} from "@uniswap/v4-core/contracts/test/PoolSwapTest.sol";
 import {PoolDonateTest} from "@uniswap/v4-core/contracts/test/PoolDonateTest.sol";
@@ -18,6 +19,7 @@ import {TickMath} from "@uniswap/v4-core/contracts/libraries/TickMath.sol";
 /// @dev Minimal initialization. Inheriting contract should set up pools and provision liquidity
 contract HookTest is Test {
     PoolManager manager;
+    PoolInitializeTest initializeRouter;
     PoolModifyPositionTest modifyPositionRouter;
     PoolSwapTest swapRouter;
     PoolDonateTest donateRouter;
@@ -45,6 +47,7 @@ contract HookTest is Test {
         manager = new PoolManager(500000);
 
         // Helpers for interacting with the pool
+        initializeRouter = new PoolInitializeTest(IPoolManager(address(manager)));
         modifyPositionRouter = new PoolModifyPositionTest(IPoolManager(address(manager)));
         swapRouter = new PoolSwapTest(IPoolManager(address(manager)));
         donateRouter = new PoolDonateTest(IPoolManager(address(manager)));

--- a/test/utils/HookTest.sol
+++ b/test/utils/HookTest.sol
@@ -24,6 +24,7 @@ contract HookTest is Test {
     TestERC20 token0;
     TestERC20 token1;
 
+    bytes constant ZERO_BYTES = new bytes(0);
     uint160 public constant MIN_PRICE_LIMIT = TickMath.MIN_SQRT_RATIO + 1;
     uint160 public constant MAX_PRICE_LIMIT = TickMath.MAX_SQRT_RATIO - 1;
 


### PR DESCRIPTION
- [x] TSTORE
    * Updated `Anvil.s.sol` to test lifecycle and verify TSTORE compatibility
- [x] Lock to initialize
    * Pool initialization now requires a router (you must `.lock()` to access `manager.initialize()`
    * Impacts testing and scripts
- [x] NoOp flag
    * Permission flag boolean is returned in `getHookCalls()`
- [x] 12 permission bits
    * The NoOp permission (and upcoming permissions) will be encoded in the top 12 bits of the hook address. Updated the hookminer accordingly