### PR TITLE
avoid the Stack too deep error

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,8 @@ ffi = true
 fs_permissions = [{ access = "read-write", path = ".forge-snapshots/"}]
 solc_version = "0.8.26"
 evm_version = "cancun"
-
+optimizer = true
+optimizer_runs = 200  # You can adjust the number of optimization runs
+via_ir = true  # Enable IR compilation
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
This should help avoid the Stack too deep error and allow you to continue running your tests.

(Ubuntu 24)
running default tests fails with "CompilerError: Stack too deep. Try compiling with --via-ir (cli) or the equivalent viaIR: true (standard JSON) while enabling the optimizer. Otherwise, try removing local variables."

Adding optimizer and via_ir fixes the tests