### PR TITLE
Keep lpFee consistent across scripts

### DIFF
--- a/script/01a_CreatePoolOnly.s.sol
+++ b/script/01a_CreatePoolOnly.s.sol
@@ -20,7 +20,7 @@ contract CreatePoolOnly is Script, Constants, Config {
 
     // --- pool configuration --- //
     // fees paid by swappers that accrue to liquidity providers
-    uint24 lpFee = 5000; // 0.30%
+    uint24 lpFee = 3000; // 0.30%
     int24 tickSpacing = 60;
 
     // starting price of the pool, in sqrtPriceX96


### PR DESCRIPTION
For some reason the lpFee in CreatePoolOnly script is initialized to 5000 and is not consistent with the value of 3000 found across the other scripts.