### PR TITLE
FS read permissions issue

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,9 +3,11 @@ src = "src"
 out = "out"
 libs = ["lib"]
 ffi = true
-fs_permissions = [{ access = "read-write", path = ".forge-snapshots/"}]
+fs_permissions = [
+    { access = "read-write", path = ".forge-snapshots/"},
+    { access = "read", path = "out/"}
+]
 solc_version = "0.8.26"
 evm_version = "cancun"
-
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
There was an issue with tests running because of an FS read access absence to the `out/` directory.

<img width="944" alt="image" src="https://github.com/user-attachments/assets/041d63a9-58d5-44cf-9cd0-63c5960fd4d4" />

It has been fixed by implicitly specifying read access to the `out/` directory.