### PR TITLE
Fix: Anvil deployment based on README fails due to usage of `address(this)` in script contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ anvil
 forge script script/Anvil.s.sol \
     --rpc-url http://localhost:8545 \
     --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
-    --broadcast
+    --broadcast --optimize --optimizer-runs 10
 ```
 
 See [script/](script/) for hook deployment, pool creation, liquidity provision, and swapping.

--- a/foundry.toml
+++ b/foundry.toml
@@ -3,6 +3,7 @@ src = "src"
 out = "out"
 libs = ["lib"]
 ffi = true
+viaIR = true
 fs_permissions = [{ access = "read-write", path = ".forge-snapshots/"}]
 solc_version = "0.8.26"
 evm_version = "cancun"

--- a/test/utils/ContextDetection.sol
+++ b/test/utils/ContextDetection.sol
@@ -11,6 +11,7 @@ library ContextDetection {
     /// @dev ref: https://getfoundry.sh/reference/cheatcodes/is-context#examples
     uint8 constant CONTEXT_TEST_GROUP = 0; // VmSafe.ForgeContext.TestGroup
 
+    /// @dev Determines whether we're running in the ctx/environment of a foundry test
     function isTest() internal view returns (bool result) {
         // vm.isContext() selector
         bytes4 selector = bytes4(keccak256("isContext(uint8)"));
@@ -23,7 +24,7 @@ library ContextDetection {
 
             // vm.isContext(CONTEXT_TEST_GROUP)
             let success := staticcall(gas(), VM_ADDRESS, ptr, 0x24, ptr, 0x20)
-            // True if successful
+            // success should simply be false in mainnet, so result = false
             if success { result := mload(ptr) }
         }
     }

--- a/test/utils/ContextDetection.sol
+++ b/test/utils/ContextDetection.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity ^0.8.21;
+
+/// @title Foundry Context Detection
+/// @notice A helper library to discern what environment we are in without having to pass the vm object.
+/// @dev Intended for use within EasyPosm due to context issues of address(this) in scripting vs test environments.
+library ContextDetection {
+    /// @dev ref: https://getfoundry.sh/forge/tests/cheatcodes/
+    address constant VM_ADDRESS = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
+
+    /// @dev ref: https://getfoundry.sh/reference/cheatcodes/is-context#examples
+    uint8 constant CONTEXT_TEST_GROUP = 0; // VmSafe.ForgeContext.TestGroup
+
+    function isTest() internal view returns (bool result) {
+        // vm.isContext() selector
+        bytes4 selector = bytes4(keccak256("isContext(uint8)"));
+
+        assembly {
+            // 4 (selector) + 32 (arg)
+            let ptr := mload(0x40)
+            mstore(ptr, selector)
+            mstore(add(ptr, 0x04), CONTEXT_TEST_GROUP)
+
+            // vm.isContext(CONTEXT_TEST_GROUP)
+            let success := staticcall(gas(), VM_ADDRESS, ptr, 0x24, ptr, 0x20)
+            // True if successful
+            if success { result := mload(ptr) }
+        }
+    }
+}

--- a/test/utils/EasyPosm.sol
+++ b/test/utils/EasyPosm.sol
@@ -8,6 +8,7 @@ import {IPositionManager} from "v4-periphery/src/interfaces/IPositionManager.sol
 import {Actions} from "v4-periphery/src/libraries/Actions.sol";
 import {SafeCast} from "v4-core/src/libraries/SafeCast.sol";
 import {PositionInfo, PositionInfoLibrary} from "v4-periphery/src/libraries/PositionInfoLibrary.sol";
+import {ContextDetection} from "./ContextDetection.sol";
 
 /// @title Easy Position Manager
 /// @notice A library for abstracting Position Manager calldata
@@ -39,11 +40,12 @@ library EasyPosm {
         uint256 deadline,
         bytes memory hookData
     ) internal returns (uint256 tokenId, BalanceDelta delta) {
+        address context = ContextDetection.isTest() ? address(this) : address(posm);
         (Currency currency0, Currency currency1) = (poolKey.currency0, poolKey.currency1);
 
         MintData memory mintData = MintData({
-            balance0Before: currency0.balanceOf(address(this)),
-            balance1Before: currency1.balanceOf(address(this)),
+            balance0Before: currency0.balanceOf(context),
+            balance1Before: currency1.balanceOf(context),
             params: new bytes[](2)
         });
         mintData.params[0] =
@@ -59,8 +61,8 @@ library EasyPosm {
         );
 
         delta = toBalanceDelta(
-            -(mintData.balance0Before - currency0.balanceOf(address(this))).toInt128(),
-            -(mintData.balance1Before - currency1.balanceOf(address(this))).toInt128()
+            -(mintData.balance0Before - currency0.balanceOf(context)).toInt128(),
+            -(mintData.balance1Before - currency1.balanceOf(context)).toInt128()
         );
     }
 
@@ -73,6 +75,7 @@ library EasyPosm {
         uint256 deadline,
         bytes memory hookData
     ) internal returns (BalanceDelta delta) {
+        address context = ContextDetection.isTest() ? address(this) : address(posm);
         (Currency currency0, Currency currency1) = getCurrencies(posm, tokenId);
 
         bytes[] memory params = new bytes[](3);
@@ -80,8 +83,8 @@ library EasyPosm {
         params[1] = abi.encode(currency0);
         params[2] = abi.encode(currency1);
 
-        uint256 balance0Before = currency0.balanceOf(address(this));
-        uint256 balance1Before = currency1.balanceOf(address(this));
+        uint256 balance0Before = currency0.balanceOf(context);
+        uint256 balance1Before = currency1.balanceOf(context);
 
         uint256 valueToPass = currency0.isAddressZero() ? amount0Max : 0;
         posm.modifyLiquidities{value: valueToPass}(
@@ -95,8 +98,8 @@ library EasyPosm {
         );
 
         delta = toBalanceDelta(
-            (currency0.balanceOf(address(this)).toInt256() - balance0Before.toInt256()).toInt128(),
-            (currency1.balanceOf(address(this)).toInt256() - balance1Before.toInt256()).toInt128()
+            (currency0.balanceOf(context).toInt256() - balance0Before.toInt256()).toInt128(),
+            (currency1.balanceOf(context).toInt256() - balance1Before.toInt256()).toInt128()
         );
     }
 
@@ -110,22 +113,23 @@ library EasyPosm {
         uint256 deadline,
         bytes memory hookData
     ) internal returns (BalanceDelta delta) {
+        address context = ContextDetection.isTest() ? address(this) : address(posm);
         (Currency currency0, Currency currency1) = getCurrencies(posm, tokenId);
 
         bytes[] memory params = new bytes[](2);
         params[0] = abi.encode(tokenId, liquidityToRemove, amount0Min, amount1Min, hookData);
         params[1] = abi.encode(currency0, currency1, recipient);
 
-        uint256 balance0Before = currency0.balanceOf(address(this));
-        uint256 balance1Before = currency1.balanceOf(address(this));
+        uint256 balance0Before = currency0.balanceOf(context);
+        uint256 balance1Before = currency1.balanceOf(context);
 
         posm.modifyLiquidities(
             abi.encode(abi.encodePacked(uint8(Actions.DECREASE_LIQUIDITY), uint8(Actions.TAKE_PAIR)), params), deadline
         );
 
         delta = toBalanceDelta(
-            (currency0.balanceOf(address(this)) - balance0Before).toInt128(),
-            (currency1.balanceOf(address(this)) - balance1Before).toInt128()
+            (currency0.balanceOf(context) - balance0Before).toInt128(),
+            (currency1.balanceOf(context) - balance1Before).toInt128()
         );
     }
 


### PR DESCRIPTION
This PR introduces context/environment detection (are we in test or script) via ContextDetection.sol in order to fix the issue of calling address(this) within EasyPosm.  From my understanding, EasyPosm being a library means the functions within it are copied to the caller's bytecode, which creates a problem when a script is the caller since they are ephemeral.

### How does this work?
It directly references the designated `vm` address specified here: https://getfoundry.sh/forge/tests/cheatcodes/
it then makes a staticcall equivalent to `vm.isContext(...)` with the id for the environment we're checking for as specified here: https://getfoundry.sh/reference/cheatcodes/is-context#examples

This allows us to make a check to see if we're in a test environment, and if so, use address(this) as was originally intended by the library.  Otherwise, use the address of posm as would normally be expected (in scripting environment).

Additionally, viaIR needed to be enabled due to a stack too deep issue when running the Anvil script.  Is there a reason this shouldn't be enabled?  Also updated readme to optimize the contracts on script run so there are no warnings of contract size too large.

With these changes, all tests pass and scripts deploy as expected.