### PR TITLE
Update for Foundry v1.4.2 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,8 @@ anvil --fork-url <YOUR_RPC_URL>
 forge script script/00_DeployHook.s.sol \
     --rpc-url http://localhost:8545 \
     --private-key 0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d \
-    --broadcast
+    --broadcast \
+    --disable-code-size-limit
 ```
 
 ### Using **RPC URLs** (actual transactions):

--- a/foundry.toml
+++ b/foundry.toml
@@ -7,6 +7,8 @@ out = "out"
 solc_version = "0.8.30"
 src = "src"
 via_ir = false
+bytecode_hash = "none"
+cbor_metadata = false
 
 [lint]
 exclude_lints = ["screaming-snake-case-immutable", "screaming-snake-case-const"]


### PR DESCRIPTION
## Summary
- Add `--disable-code-size-limit` flag to Anvil deployment instructions
- Add bytecode optimization settings to foundry.toml

## Context
Foundry v1.4.2 (latest release from October 18, 2025) now enforces contract size limits during script execution. The PoolManager contract (35,264 bytes) exceeds the standard 24,576 byte limit, causing deployment failures for developers following the README instructions.

## Changes
1. **README.md**: Updated the Anvil deployment command to include `--disable-code-size-limit` flag
2. **foundry.toml**: Added `bytecode_hash = "none"` and `cbor_metadata = false` for bytecode optimization

## Testing
- Fresh `forge install` works correctly
- `forge build` compiles all contracts successfully  
- All tests pass
- Anvil deployment script works with new flags
- Verified complete out-of-the-box experience for new developers

This ensures the v4-template works seamlessly for hackathon developers using the latest Foundry version.